### PR TITLE
Compatibility with python version lower than 3.10

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import sys
 from catkin_pkg.package import (


### PR DESCRIPTION
When running the script with python 3.8 I found problems with annotations:

```
  File "/tmp/tmpy2yi33ng/gz_vendor/create_gz_vendor_pkg/create_vendor_package.py", line 204, in <module>
    def create_vendor_package_xml(src_pkg_xml: Package, existing_package: Package | None):
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

Adding the future clause solved it.