### PR TITLE
Add gz_vendor.repos

### DIFF
--- a/gz_vendor.repos
+++ b/gz_vendor.repos
@@ -1,0 +1,73 @@
+repositories:
+  gz_dartsim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gazebo_dartsim_vendor.git
+    version: rolling
+  gz_libs/gz_cmake_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_cmake_vendor.git
+    version: rolling
+  gz_libs/gz_common_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_common_vendor.git
+    version: rolling
+  gz_libs/gz_fuel_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+    version: rolling
+  gz_libs/gz_gui_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_gui_vendor.git
+    version: rolling
+  gz_libs/gz_launch_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_launch_vendor.git
+    version: rolling
+  gz_libs/gz_math_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_math_vendor.git
+    version: rolling
+  gz_libs/gz_msgs_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_msgs_vendor.git
+    version: rolling
+  gz_libs/gz_physics_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_physics_vendor.git
+    version: rolling
+  gz_libs/gz_plugin_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_plugin_vendor.git
+    version: rolling
+  gz_libs/gz_rendering_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_rendering_vendor.git
+    version: rolling
+  gz_libs/gz_sensors_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sensors_vendor.git
+    version: rolling
+  gz_libs/gz_sim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sim_vendor.git
+    version: rolling
+  gz_libs/gz_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_tools_vendor.git
+    version: rolling
+  gz_libs/gz_transport_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_transport_vendor.git
+    version: rolling
+  gz_libs/gz_utils_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_utils_vendor.git
+    version: rolling
+  gz_libs/sdformat_vendor:
+    type: git
+    url: https://github.com/gazebo-release/sdformat_vendor.git
+    version: rolling
+  gz_ogre_next_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gazebo_ogre_next_vendor.git
+    version: rolling


### PR DESCRIPTION
Based on the conversation in https://github.com/gazebo-release/gz_sim_vendor/issues/3#issuecomment-2272839150, this adds a `.repos` file that can be used to clone all `gz_vendor` packages. In that comment, it was suggested we create ROS distro specific branches (e.g. `jazzy`, `rolling`), but since none of the other contents of this repo are distro specific, I don't think we should do that. Users can use `vcstool` to checkout the branch they need (e.g. `vcs custom --args checkout jazzy`).
