### PR TITLE
Drop the BUILD_DOCS cmake argument on Ionic

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -46,7 +46,7 @@ EXTRA_VENDORED_PKGS = {
 
 # These dependencies will be removed from the package.xml provided by the upstream Gazebo library
 DEPENDENCY_DISALLOW_LIST = [
-    # python3-distutio is not needed for CMake > 3.12. Also, it is currently failing to install on Noble
+    # python3-distutils is not needed for CMake > 3.12. Also, it is currently failing to install on Noble
     "python3-distutils",
 ]
 

--- a/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
+++ b/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
@@ -6,6 +6,7 @@ project({{ vendor_name }})
 set(LIB_VER_MAJOR {{ version.major }})
 set(LIB_VER_MINOR {{ version.minor }})
 set(LIB_VER_PATCH {{ version.patch }})
+set(LIB_VER_SUFFIX "{{ version_suffix }}")
 
 # Derived variables
 set(LIB_NAME {{ cmake_pkg_name }})
@@ -50,7 +51,7 @@ find_package(${LIB_NAME_FULL} ${VERSION_MATCH} ${LIB_VER} COMPONENTS all QUIET)
 ament_vendor(${LIB_NAME_UNDERSCORE}_vendor
   SATISFIED ${${LIB_NAME_FULL}_FOUND}
   VCS_URL https://github.com/gazebosim/${GITHUB_NAME}.git
-  VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}
+  VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX}
 {% if cmake_args %}
   CMAKE_ARGS
   {% for arg in cmake_args %}


### PR DESCRIPTION
 The CMake argument -DBUILD_DOCS was deprecated in Ionic. It now generated a warning, so we need to remove it from vendor packages targetting Ionic. To determine this we check if the package itself is gz-cmake4 or depends on gz-cmake4 or later.