### PR TITLE
Use spdlog_vendor in place of spdlog

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -42,6 +42,7 @@ EXTRA_VENDORED_PKGS = {
     "DART": "gz_dartsim_vendor",
     "libogre-next-2.3-dev": "gz_ogre_next_vendor",
     "libogre-next-2.3": "gz_ogre_next_vendor",
+    "spdlog": "spdlog_vendor",
 }
 
 # These dependencies will be removed from the package.xml provided by the upstream Gazebo library


### PR DESCRIPTION
`spdlog` is not being properly found on ROS windows builds. Example: https://ci.ros2.org/view/nightly/job/nightly_win_rel/3158/cmake/new/. This will replace instances of `spdlog` in the upstream package with `spdlog_vendor`.

Running this on gz-utils at 3c58be65f5d56fbab2bad1a01a45841d71666448 with #8 and #7 merged generates the following diff that matches https://github.com/gazebo-release/gz_utils_vendor/pull/6:

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 4286745..bc17303 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 find_package(ament_cmake_export_dependencies REQUIRED)
 
 find_package(gz_cmake_vendor REQUIRED)
+find_package(spdlog_vendor REQUIRED)
 
 # Set the VERSION_MATCH to "EXACT" by default, but relax the requirement
 # if we are users are building from source (determined by the
@@ -57,6 +58,7 @@ endif()
 
 ament_export_dependencies(
   gz_cmake_vendor
+  spdlog_vendor
 )
 
 if(NOT ${${LIB_NAME_FULL}_FOUND})
diff --git a/package.xml b/package.xml
index 81050e0..45adfd7 100644
--- a/package.xml
+++ b/package.xml
@@ -24,9 +24,8 @@
   <buildtool_depend>ament_cmake_test</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
-  <build_depend>spdlog</build_depend>
-  <exec_depend>spdlog</exec_depend>
   <depend>gz_cmake_vendor</depend>
+  <depend>spdlog_vendor</depend>
 
   <!-- Depend on the package we are vendoring to allow building it from source -->
   <depend condition="$GZ_BUILD_FROM_SOURCE != ''">gz-utils3</depend>

```

more context: https://github.com/gazebosim/gz-utils/pull/146