### PR TITLE
Add .sh env hook for setting GZ_CONFIG_PATH

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -407,6 +407,10 @@ def main(argv=sys.argv[1:]):
                 templates_path / "vendor.dsv.in",
                 Path(args.output_dir) / f"{vendor_name}.dsv.in",
             )
+            shutil.copy(
+                templates_path / "vendor.sh.in",
+                Path(args.output_dir) / f"{vendor_name}.sh.in",
+            )
 
 
 if __name__ == "__main__":

--- a/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
+++ b/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
@@ -86,10 +86,7 @@ ament_export_dependencies(
 {% if vendor_has_dsv %}
 if(NOT ${${LIB_NAME_FULL}_FOUND})
   ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv.in")
-  # Create a dummy .sh file needed for ament_package to source the .dsv file.
-  # See https://github.com/ament/ament_package/issues/145
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh "# Dummy .sh file needed for .dsv file to be sourced.")
-  ament_environment_hooks("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh")
+  ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.sh.in")
 endif()
 {% endif %}
 

--- a/create_gz_vendor_pkg/templates/vendor.sh.in
+++ b/create_gz_vendor_pkg/templates/vendor.sh.in
@@ -1,0 +1,3 @@
+if [ -d "$AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/share/gz" ]; then
+  ament_prepend_unique_value GZ_CONFIG_PATH "$AMENT_CURRENT_PREFIX/opt/@PROJECT_NAME@/share/gz"
+fi


### PR DESCRIPTION
For systems not using colcon's or ament's `.dsv` files for initializing the environment, having only "dummy" `.sh` hooks means that the `GZ_CONFIG_PATH` environment variable does not get set correctly. The proposed change is to define a "real" `.sh` hook with the proper logic to initialize the environment.

This generates the exact same output as was proposed in https://github.com/gazebo-release/gz_common_vendor/pull/5.