### PR TITLE
Disallow rubocop dependency

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -49,6 +49,10 @@ EXTRA_VENDORED_PKGS = {
 DEPENDENCY_DISALLOW_LIST = [
     # python3-distutils is not needed for CMake > 3.12. Also, it is currently failing to install on Noble
     "python3-distutils",
+    # rubocop is only needed for tests/linting which we don't need for vendor packages.
+    # It's also not available on RHEL, which prevents all vendor packages that depend
+    # on gz-tools from being released on RHEL.
+    "rubocop",
 ]
 
 # These were taken from catkin_pkg's package.py file


### PR DESCRIPTION
We're currently not releasing gz_tools_vendor on RHEL because of a missing dependency (rubocop). And since sdformat_vendor depends on gz_tools_vendor, that is also not available on RHEL. This is blocking https://github.com/ros-controls/ros2_control/pull/1763 from being merged. The quickest fix is to add rubocop to the disallow list since it's only used for testing, which we don't do for the vendor packages.