### PR TITLE
Add option VENDOR_FROM_LIB_VCS_REF

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -168,6 +168,15 @@ def split_version(version: str):
     return {"major": new_version[0], "minor": new_version[1], "patch": new_version[2]}
 
 
+def get_default_lib_vcs_ref(pkg_name: str):
+    # Returns the branch name used in the latest Gazebo release
+    # Jetty still uses gz-tools2
+    if pkg_name in ["gz-tools2"]:
+        return pkg_name
+    # All other Jetty branches are main
+    return "main"
+
+
 def get_lib_designator(pkg_name: str):
     gz_match = re.match(r"gz-(.*)", pkg_name)
     if gz_match:
@@ -300,6 +309,7 @@ def create_cmake_file(src_pkg_xml: Package, extra_params: dict):
     params["gz_vendor_deps"], params["pkg"] = separate_and_vendorize_gz_deps(
         src_pkg_xml
     )
+    params["default_lib_vcs_ref"] = get_default_lib_vcs_ref(params["pkg"].name)
 
     pkg_name_no_version, pkg_version = remove_version(params["pkg"].name, return_version=True)
     params["github_pkg_name"] = github_pkg_name(pkg_name_no_version)

--- a/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
+++ b/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
@@ -16,6 +16,17 @@ set(LIB_NAME_COMP_PREFIX ${LIB_NAME})
 set(LIB_NAME_FULL ${LIB_NAME}${LIB_VER_MAJOR})
 set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})
 
+option(VENDOR_FROM_LIB_VCS_REF
+  "Vendor from a VCS ref instead of tag. Uses the value in LIB_VCS_REF if specified or main otherwise"
+  OFF)
+if(NOT VENDOR_FROM_LIB_VCS_REF)
+  set(LIB_VCS_VER ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX})
+elseif(LIB_VCS_REF)
+  set(LIB_VCS_VER ${LIB_VCS_REF})
+else()
+  set(LIB_VCS_VER main)
+endif()
+
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 find_package(ament_cmake_export_dependencies REQUIRED)
@@ -51,7 +62,7 @@ find_package(${LIB_NAME_FULL} ${VERSION_MATCH} ${LIB_VER} COMPONENTS all QUIET)
 ament_vendor(${LIB_NAME_UNDERSCORE}_vendor
   SATISFIED ${${LIB_NAME_FULL}_FOUND}
   VCS_URL https://github.com/gazebosim/${GITHUB_NAME}.git
-  VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX}
+  VCS_VERSION ${LIB_VCS_VER}
 {% if cmake_args %}
   CMAKE_ARGS
   {% for arg in cmake_args %}

--- a/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
+++ b/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
@@ -24,7 +24,7 @@ if(NOT VENDOR_FROM_LIB_VCS_REF)
 elseif(LIB_VCS_REF)
   set(LIB_VCS_VER ${LIB_VCS_REF})
 else()
-  set(LIB_VCS_VER main)
+  set(LIB_VCS_VER {{ default_lib_vcs_ref }})
 endif()
 
 find_package(ament_cmake_core REQUIRED)


### PR DESCRIPTION
This allows vendoring from a specified vcs ref instead of the hard-coded tag. When this option is set to true, a branch, tag, or commit can be specified in the
`LIB_VCS_REF` variable. If `LIB_VCS_REF` is unspecified, vendoring will use `main`.

