### PR TITLE
Fix error when running generating a completely new vendor package

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -393,7 +393,7 @@ def main(argv=sys.argv[1:]):
     except FileExistsError:
         pass
 
-    # Check if there is a package.xml in the output directory. If so, we are updating ane existing vendor package
+    # Check if there is a package.xml in the output directory. If so, we are updating an existing vendor package
     existing_package = None
     existing_package_path = Path(args.output_dir) / "package.xml"
     if existing_package_path.exists():

--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -393,12 +393,15 @@ def main(argv=sys.argv[1:]):
     except FileExistsError:
         pass
 
+    # Check if there is a package.xml in the output directory. If so, we are updating ane existing vendor package
+    existing_package = None
     existing_package_path = Path(args.output_dir) / "package.xml"
-    try:
-        existing_package = parse_package(existing_package_path)
-    except InvalidPackage as e:
-        print(f"Error parsing '{existing_package_path}")
-        raise e
+    if existing_package_path.exists():
+        try:
+            existing_package = parse_package(existing_package_path)
+        except InvalidPackage as e:
+            print(f"Error parsing '{existing_package_path}")
+            raise e
 
     generate_vendor_package_files(package, existing_package, args.output_dir, params)
 


### PR DESCRIPTION
The script was failing when running it to create a new vendor package. This PR properly handles the case where there is no `package.xml` in the output directory. With this you should be able to run


```bash
# Create CMakeLists.txt, package.xml, CONTRIBUTING.md, LICENSE
create_vendor_package.py path/to/ionic/gz-sim/package.xml
# or with `--overwrite_cmake_configs` to generate the *.in files as well
create_vendor_package.py path/to/ionic/gz-sim/package.xml --overwrite_cmake_configs
```