### PR TITLE
Jetty: support package names without version number

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -222,7 +222,7 @@ def pkg_has_docs(pkg_name_no_version):
 
 
 def cmake_pkg_name(pkg_name_no_version):
-    # gz-fuel-tools needs special care as it's cmake package name is different
+    # gz-fuel-tools needs special care as its cmake package name is different
     # from its deb package name.
     if pkg_name_no_version == "gz-fuel-tools":
         return "gz-fuel_tools"
@@ -230,7 +230,7 @@ def cmake_pkg_name(pkg_name_no_version):
 
 
 def cmake_pkg_name_full(pkg_name):
-    # gz-fuel-tools needs special care as it's cmake package name is different
+    # gz-fuel-tools needs special care as its cmake package name is different
     # from its deb package name.
     if pkg_name.startswith("gz-fuel-tools"):
         return pkg_name.replace("fuel-tools", "fuel_tools")

--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -115,15 +115,15 @@ def build_docs_deprecated(package: Package):
         source/upstream package.xml
     """
 
-    def is_gz_cmake4(name):
-        pkg_name, pkg_version = remove_version(name, return_version=True)
-        return pkg_name == "gz-cmake" and int(pkg_version) >= 4
+    def is_gz_cmake4_or_later(name):
+        pkg_name_no_version, pkg_version = remove_version(name, return_version=True)
+        return name == "gz-cmake" or (pkg_name_no_version == "gz-cmake" and int(pkg_version) >= 4)
 
-    if is_gz_cmake4(package.name):
+    if is_gz_cmake4_or_later(package.name):
         return True
     else:
         for dep in package.build_depends:
-            if is_gz_cmake4(dep.name):
+            if is_gz_cmake4_or_later(dep.name):
                 return True
     return False
 
@@ -203,8 +203,8 @@ def pkg_has_dsv(pkg_name_no_version):
     return pkg_name_no_version not in ["gz-tools", "gz-cmake"]
 
 
-def pkg_has_patches(pkg_name_no_version, pkg_version):
-    if pkg_name_no_version == "gz-cmake" and int(pkg_version) < 4:
+def pkg_has_patches(pkg_name_no_version, pkg_major_version):
+    if pkg_name_no_version == "gz-cmake" and int(pkg_major_version) < 4:
         return True
     return pkg_name_no_version in ["gz-rendering"]
 

--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -334,7 +334,7 @@ def create_cmake_file(src_pkg_xml: Package, extra_params: dict):
     if pkg_has_docs(pkg_name_no_version) and not build_docs_deprecated(src_pkg_xml):
         params["cmake_args"] = ["-DBUILD_DOCS:BOOL=OFF"]
 
-    if pkg_has_pybind11(pkg_name_no_version):
+    if pkg_has_pybind11(pkg_name_no_version) and params["versioned_package_name"]:
         params["cmake_args"].append("-DSKIP_PYBIND11:BOOL=ON")
     if pkg_has_swig(pkg_name_no_version):
         params["cmake_args"].append("-DSKIP_SWIG:BOOL=ON")
@@ -403,7 +403,7 @@ def main(argv=sys.argv[1:]):
 
     # check for gz-cmake in package.name or dependences to indicate whether package name includes version
     params["versioned_package_name"] = True
-    if "gz-cmake" in [package.name] + package.build_depends:
+    if "gz-cmake" in [package.name] + [dep.name for dep in package.build_depends]:
         params["versioned_package_name"] = False
         if package.name[-1].isdigit():
             raise RuntimeError("Package %s has a number in the name but depends on gz-cmake" % package.name)

--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -229,6 +229,14 @@ def cmake_pkg_name(pkg_name_no_version):
     return pkg_name_no_version
 
 
+def cmake_pkg_name_full(pkg_name):
+    # gz-fuel-tools needs special care as it's cmake package name is different
+    # from its deb package name.
+    if pkg_name.startswith("gz-fuel-tools"):
+        return pkg_name.replace("fuel-tools", "fuel_tools")
+    return pkg_name
+
+
 def github_pkg_name(pkg_name_no_version):
     # gz-fuel-tools needs special care as github name is different from its package.xml name
     if pkg_name_no_version == "gz-fuel_tools":
@@ -284,7 +292,7 @@ def create_vendor_package_xml(
         src_pkg_xml
     )
 
-    pkg_name_no_version = remove_version(params["pkg"].name)
+    pkg_name_no_version = params["pkg_name_no_version"]
     params["vendor_name"] = create_vendor_name(pkg_name_no_version)
 
     params["vendor_pkg_version"] = (
@@ -311,15 +319,16 @@ def create_cmake_file(src_pkg_xml: Package, extra_params: dict):
     )
     params["default_lib_vcs_ref"] = get_default_lib_vcs_ref(params["pkg"].name)
 
-    pkg_name_no_version, pkg_version = remove_version(params["pkg"].name, return_version=True)
+    pkg_name_no_version = params["pkg_name_no_version"]
     params["github_pkg_name"] = github_pkg_name(pkg_name_no_version)
     params["vendor_name"] = create_vendor_name(pkg_name_no_version)
     params["cmake_pkg_name"] = cmake_pkg_name(pkg_name_no_version)
+    params["cmake_pkg_name_full"] = cmake_pkg_name_full(params["pkg"].name)
 
     params["vendor_has_extra_cmake"] = pkg_has_extra_cmake(pkg_name_no_version)
     params["vendor_has_dsv"] = pkg_has_dsv(pkg_name_no_version)
-    params["has_patches"] = pkg_has_patches(pkg_name_no_version, pkg_version)
     params["version"] = split_version(params["pkg"].version)
+    params["has_patches"] = pkg_has_patches(pkg_name_no_version, params["version"]["major"])
 
     params["cmake_args"] = []
     if pkg_has_docs(pkg_name_no_version) and not build_docs_deprecated(src_pkg_xml):
@@ -392,8 +401,17 @@ def main(argv=sys.argv[1:]):
         cmake_file_path = Path(args.input_package_xml.name).parent / "CMakeLists.txt"
         params["version_suffix"] = parse_version_suffix(cmake_file_path)
 
-    pkg_name_no_version = remove_version(package.name)
-    vendor_name = create_vendor_name(pkg_name_no_version)
+    # check for gz-cmake in package.name or dependences to indicate whether package name includes version
+    params["versioned_package_name"] = True
+    if "gz-cmake" in [package.name] + package.build_depends:
+        params["versioned_package_name"] = False
+        if package.name[-1].isdigit():
+            raise RuntimeError("Package %s has a number in the name but depends on gz-cmake" % package.name)
+        params["pkg_name_no_version"] = package.name
+    else:
+        params["pkg_name_no_version"] = remove_version(package.name)
+
+    vendor_name = create_vendor_name(params["pkg_name_no_version"])
 
     if not args.output_dir:
         args.output_dir = vendor_name
@@ -421,17 +439,18 @@ def main(argv=sys.argv[1:]):
         shutil.copy(templates_path / file, Path(args.output_dir) / file)
 
     if args.overwrite_cmake_configs:
-        shutil.copy(
-            templates_path / "config.cmake.in",
-            Path(args.output_dir)
-            / f"{cmake_pkg_name(pkg_name_no_version)}-config.cmake.in",
-        )
-        shutil.copy(
-            templates_path / "extras.cmake.in",
-            Path(args.output_dir) / f"{vendor_name}-extras.cmake.in",
-        )
+        if params["versioned_package_name"]:
+            shutil.copy(
+                templates_path / "config.cmake.in",
+                Path(args.output_dir)
+                / f"{cmake_pkg_name(params['pkg_name_no_version'])}-config.cmake.in",
+            )
+            shutil.copy(
+                templates_path / "extras.cmake.in",
+                Path(args.output_dir) / f"{vendor_name}-extras.cmake.in",
+            )
 
-        if pkg_has_dsv(pkg_name_no_version):
+        if pkg_has_dsv(params["pkg_name_no_version"]):
             shutil.copy(
                 templates_path / "vendor.dsv.in",
                 Path(args.output_dir) / f"{vendor_name}.dsv.in",

--- a/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
+++ b/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
@@ -13,7 +13,7 @@ set(LIB_NAME {{ cmake_pkg_name }})
 set(GITHUB_NAME {{ github_pkg_name }})
 string(REPLACE "-" "_" LIB_NAME_UNDERSCORE ${LIB_NAME})
 set(LIB_NAME_COMP_PREFIX ${LIB_NAME})
-set(LIB_NAME_FULL ${LIB_NAME}${LIB_VER_MAJOR})
+set(LIB_NAME_FULL {{ cmake_pkg_name_full }})
 set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})
 
 option(VENDOR_FROM_LIB_VCS_REF
@@ -104,6 +104,7 @@ if(NOT ${${LIB_NAME_FULL}_FOUND})
 endif()
 {% endif %}
 
+{% if versioned_package_name %}
 # The goal is to support versionless package names once the user has found the
 # vendor package. Example usage:
 #
@@ -140,3 +141,6 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}-config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}-config-version.cmake
         DESTINATION "opt/${PROJECT_NAME}/extra_cmake/lib/cmake/${LIB_NAME}")
+{% else %}
+ament_package()
+{% endif %}

--- a/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
+++ b/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
@@ -17,7 +17,7 @@ set(LIB_NAME_FULL {{ cmake_pkg_name_full }})
 set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})
 
 option(VENDOR_FROM_LIB_VCS_REF
-  "Vendor from a VCS ref instead of tag. Uses the value in LIB_VCS_REF if specified or main otherwise"
+  "Vendor from a VCS ref instead of tag. Uses the value in LIB_VCS_REF if specified or {{ default_lib_vcs_ref }} otherwise"
   OFF)
 if(NOT VENDOR_FROM_LIB_VCS_REF)
   set(LIB_VCS_VER ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX})


### PR DESCRIPTION
Replacement for https://github.com/gazebo-tooling/gz_vendor/pull/17.

Per https://github.com/gazebo-tooling/release-tools/issues/1244, version numbers have been removed from package names in Jetty (except for gz-tools2). This adds logic to detect packages with unversioned names based on whether the package is named `gz-cmake` or depends on `gz-cmake` (without version). It also cleans up some logic to get package version numbers directly from the package.xml file using the `split_version` helper since it may not be available from the package name.

Extra cmake config files are not written or installed for packages with unversioned names, and python bindings are enabled by removing the `SKIP_PYBIND11` cmake argument.