### PR TITLE
Vendor CLI11 in gz-utils

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -335,7 +335,7 @@ def create_cmake_file(src_pkg_xml: Package, extra_params: dict):
         params["cmake_args"] = ["-DBUILD_DOCS:BOOL=OFF"]
 
     # CLI11 is not available on ci.ros2.org, which uses a curated list of dependencies instead of rosdep.
-    # TODO(azeey): Remove this once ros2/cli#825 and ros2/ros2#1745 are merged
+    # TODO(azeey): Remove this once ros2/ci#825 and ros2/ros2#1745 are merged
     if pkg_name_no_version == "gz-utils":
         params["cmake_args"].append("-DGZ_UTILS_VENDOR_CLI11=ON")
 


### PR DESCRIPTION
CLI11 is not yet available on ci.ros2.org, so use the vendored version