### PR TITLE
Set PYTHONPATH for unversioned packages

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -464,6 +464,11 @@ def main(argv=sys.argv[1:]):
                 templates_path / "vendor.dsv.in",
                 Path(args.output_dir) / f"{vendor_name}.dsv.in",
             )
+            if not params["versioned_package_name"]:
+                shutil.copy(
+                    templates_path / "pythonpath.dsv.in",
+                    Path(args.output_dir) / f"{vendor_name}_pythonpath.dsv.in",
+                )
 
 
 if __name__ == "__main__":

--- a/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
+++ b/create_gz_vendor_pkg/templates/CMakeLists.txt.jinja
@@ -101,6 +101,10 @@ if(NOT ${${LIB_NAME_FULL}_FOUND})
   # See https://github.com/ament/ament_package/issues/145
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh "# Dummy .sh file needed for .dsv file to be sourced.")
   ament_environment_hooks("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh")
+{%    if not versioned_package_name %}
+  # environment hook for setting PYTHONPATH
+  ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_pythonpath.dsv.in")
+{%    endif %}
 endif()
 {% endif %}
 

--- a/create_gz_vendor_pkg/templates/pythonpath.dsv.in
+++ b/create_gz_vendor_pkg/templates/pythonpath.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate-if-exists;PYTHONPATH;opt/@PROJECT_NAME@/lib/python

--- a/create_gz_vendor_pkg/templates/vendor.dsv.in
+++ b/create_gz_vendor_pkg/templates/vendor.dsv.in
@@ -1,5 +1,1 @@
 prepend-non-duplicate-if-exists;GZ_CONFIG_PATH;opt/@PROJECT_NAME@/share/gz
-{% # only set PYTHONPATH for unversioned packages (Jetty and newer) %}
-{% if not versioned_package_name %}
-prepend-non-duplicate-if-exists;PYTHONPATH;opt/@PROJECT_NAME@/lib/python
-{% endif %}

--- a/create_gz_vendor_pkg/templates/vendor.dsv.in
+++ b/create_gz_vendor_pkg/templates/vendor.dsv.in
@@ -1,1 +1,5 @@
 prepend-non-duplicate-if-exists;GZ_CONFIG_PATH;opt/@PROJECT_NAME@/share/gz
+{% # only set PYTHONPATH for unversioned packages (Jetty and newer) %}
+{% if not versioned_package_name %}
+prepend-non-duplicate-if-exists;PYTHONPATH;opt/@PROJECT_NAME@/lib/python
+{% endif %}


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/gz_vendor/issues/2.

All of our packages that build python bindings install them to `lib/python` by default. This sets the `PYTHONPATH` appropriately for unversioned (Jetty and later) packages using `prepend-non-duplicate-if-exists` to match the approach taken with `GZ_CONFIG_PATH`. This will cause an update to all Jetty vendor packages with a `dsv` file (everything other than gz-cmake and gz-tools), even those without python bindings since the `prepend-non-duplicate-if-exists` handles the logic for checking whether `libs/python` exists.