### PR TITLE
Overwrite CMake configs by default

### DIFF
--- a/create_gz_vendor_pkg/create_vendor_package.py
+++ b/create_gz_vendor_pkg/create_vendor_package.py
@@ -391,7 +391,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         "--overwrite_cmake_configs",
         action="store_true",
-        default=False,
+        default=True,
         help="If true, overwrites cmake config (.in) files",
     )
     args = parser.parse_args(argv)

--- a/create_gz_vendor_pkg/templates/config.cmake.in
+++ b/create_gz_vendor_pkg/templates/config.cmake.in
@@ -2,23 +2,25 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
 find_package(@LIB_NAME@@LIB_VER_MAJOR@ ${@LIB_NAME@_FIND_VERSION} REQUIRED COMPONENTS ${@LIB_NAME@_FIND_COMPONENTS})
 
-# Set up the core library and add it to the list of all components
-add_library(@LIB_NAME_COMP_PREFIX@::@LIB_NAME_COMP_PREFIX@ ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
-add_library(@LIB_NAME_COMP_PREFIX@::core ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
+if (NOT "@LIB_NAME@" STREQUAL "gz-cmake")
+  # Set up the core library and add it to the list of all components
+  add_library(@LIB_NAME_COMP_PREFIX@::@LIB_NAME_COMP_PREFIX@ ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
+  add_library(@LIB_NAME_COMP_PREFIX@::core ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
 
-# Retrieve the list of components
-get_target_property(components @LIB_NAME@@LIB_VER_MAJOR@::requested INTERFACE_LINK_LIBRARIES)
+  # Retrieve the list of components
+  get_target_property(components @LIB_NAME@@LIB_VER_MAJOR@::requested INTERFACE_LINK_LIBRARIES)
 
-foreach(component ${components})
-  # Skip the core library
-  if(${component} STREQUAL @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
-    continue()
-  endif()
+  foreach(component ${components})
+    # Skip the core library
+    if(${component} STREQUAL @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
+      continue()
+    endif()
 
-  # Change "gz-libN::gz-libN-component" to "component"
-  string(REGEX REPLACE "@LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@-" "" component_name ${component})
-  add_library(@LIB_NAME_COMP_PREFIX@::${component_name} ALIAS ${component})
-endforeach()
+    # Change "gz-libN::gz-libN-component" to "component"
+    string(REGEX REPLACE "@LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@-" "" component_name ${component})
+    add_library(@LIB_NAME_COMP_PREFIX@::${component_name} ALIAS ${component})
+  endforeach()
 
-# Add a root gz-lib alias
-add_library(@LIB_NAME_COMP_PREFIX@ ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
+  # Add a root gz-lib alias
+  add_library(@LIB_NAME_COMP_PREFIX@ ALIAS @LIB_NAME@@LIB_VER_MAJOR@::@LIB_NAME@@LIB_VER_MAJOR@)
+endif()


### PR DESCRIPTION
The default was set to False because we had made a manual change in `gz_cmake_vendor` that we didn't want to overwrite. However, this causes problems when we introduce new config files. For example, we recently added a `.in` files to configure PYTHONPATH for each vendor package. Since the default is False, when the vendor package is created by `release-tools/release.py`, it doesn't include the new config files.

The solution here to programmatically achieve what was done manually in gz_cmake_vendor and set `overwrite_cmake_configs` to True by default.

See https://github.com/gazebo-release/gz_utils_vendor/pull/12 for a failing PR.

To test this run the following in `gz_utils_vendor`:
```
python3 <path to gz_vendor>/create_vendor_package.py <path to jetty gz-utils>/package.xml  --output_dir .
```
Note that `<path to jetty gz-utils>` is the upstream Jetty `gz-utils`, not the vendor package.

Before this PR, it will not generate the `pythonpath.dsv.in` file.

You can also test this by running it on gz-cmake in the `kilted` branch, which corresponds to Gazebo Ionic.
```
cd gz_cmake_vendor
git checkout kilted
python3 <path to gz_vendor>/create_vendor_package.py <path to ionic gz-cmake>/package.xml  --output_dir .
```

The generated `gz-cmake-config.cmake.in` will now have
```
if (NOT "@LIB_NAME@" STREQUAL "gz-cmake")
```

You can then build the workspace up-to `gz_utils_vendor` and test that the following CMake project
works:
```c++
// test.cpp
int main() {
  return 0;
}
```
```cmake
# CMakeLists.txt
cmake_minimum_required(VERSION 3.10)
project(test_config_changes)

find_package(gz_cmake_vendor)
find_package(gz-cmake)

find_package(gz_utils_vendor)
find_package(gz-utils)

add_executable(test test.cpp)
target_link_libraries(test gz-utils::gz-utils)
```

Before this PR, the generated config files would fail at `find_package(gz-cmake)`
